### PR TITLE
feat: deprecate Contains, Index, and GroupByLen in favor of stdlib equivalents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,27 @@ docs: update README with new examples
 
 ## Go Version
 
-This project requires **Go 1.24.0** or later (specified in `go.mod`).
+This project requires **Go 1.25** or later (specified in `go.mod`).
+
+## Deprecation Policy
+
+As the Go standard library evolves, some functions in this library may be superseded by stdlib equivalents. When this happens:
+
+1. Functions are marked as deprecated with clear migration paths in code comments
+2. Deprecated functions remain functional until v1.0.0 to maintain backward compatibility
+3. Documentation is updated to recommend stdlib alternatives with migration examples
+4. Users are given advance notice through release notes and deprecation warnings
+
+### Currently Deprecated (v0.11.0+)
+
+The following functions are deprecated in favor of Go standard library equivalents:
+
+- **`Contains`** → Use `slices.Contains` from the standard library (available since Go 1.21)
+- **`Index`** → Use `slices.Index` from the standard library (available since Go 1.21)
+- **`GroupByLen`** → Use `slices.Chunk` from the standard library (available since Go 1.23)
+  - Note: `slices.Chunk` returns an iterator rather than a materialized slice
+
+These functions will be removed in v1.0.0. See README.md for migration examples.
 
 ## Branch Strategy
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Built with **Go generics**, this library offers:
 go get github.com/spandigital/slices
 ```
 
-**Requirements:** Go 1.24.0 or later
+**Requirements:** Go 1.25 or later
 
 ## Quick Start
 
@@ -53,6 +53,44 @@ func main() {
     // Get unique values
     unique := slices.Unique([]int{1, 2, 2, 3, 3, 3})
     fmt.Println(unique) // [1, 2, 3]
+}
+```
+
+## ⚠️ Deprecation Notice
+
+The following functions are deprecated and will be removed in v1.0.0. Please migrate to the Go standard library equivalents:
+
+| Deprecated Function | Standard Library Replacement | Available Since |
+|-------------------|------------------------------|-----------------|
+| `Contains` | `slices.Contains` | Go 1.21 |
+| `Index` | `slices.Index` | Go 1.21 |
+| `GroupByLen` | `slices.Chunk` | Go 1.23 |
+
+### Migration Examples
+
+For `Contains` and `Index`, simply change the import:
+
+```go
+// Old (deprecated)
+import "github.com/spandigital/slices"
+result := slices.Contains(mySlice, value)
+
+// New (recommended)
+import "slices"
+result := slices.Contains(mySlice, value)
+```
+
+For `GroupByLen`, use the iterator-based `slices.Chunk`:
+
+```go
+// Old (deprecated)
+chunks := slices.GroupByLen(mySlice, 3)
+
+// New (recommended)
+import "slices"
+var chunks [][]int
+for chunk := range slices.Chunk(mySlice, 3) {
+    chunks = append(chunks, chunk)
 }
 ```
 
@@ -97,7 +135,9 @@ clean := slices.RemoveNil(values)
 // Result: [1, "hello", 3.14]
 ```
 
-#### `Contains[S ~[]E, E comparable](s S, v E) bool`
+#### `Contains[S ~[]E, E comparable](s S, v E) bool` ⚠️ Deprecated
+
+**Deprecated:** Use `slices.Contains` from the standard library instead. This function will be removed in v1.0.0.
 
 Check if a slice contains a specific value.
 
@@ -106,7 +146,9 @@ hasValue := slices.Contains([]int{1, 2, 3, 4, 5}, 3) // true
 noValue := slices.Contains([]string{"foo", "bar"}, "baz") // false
 ```
 
-#### `Index[S ~[]E, E comparable](s S, v E) int`
+#### `Index[S ~[]E, E comparable](s S, v E) int` ⚠️ Deprecated
+
+**Deprecated:** Use `slices.Index` from the standard library instead. This function will be removed in v1.0.0.
 
 Find the index of a value in a slice. Returns -1 if not found.
 
@@ -226,7 +268,9 @@ byAge := slices.GroupBy(people, func(p Person) int {
 // }
 ```
 
-#### `GroupByLen[S ~[]V, V any](input S, length int) [][]V`
+#### `GroupByLen[S ~[]V, V any](input S, length int) [][]V` ⚠️ Deprecated
+
+**Deprecated:** Use `slices.Chunk` from the standard library instead. This function will be removed in v1.0.0. Note that `slices.Chunk` returns an iterator, not a materialized slice.
 
 Split a slice into chunks of a specified length.
 

--- a/contains.go
+++ b/contains.go
@@ -1,6 +1,16 @@
 package slices
 
+import "slices"
+
 // Contains reports whether v is present in s.
+//
+// Deprecated: Use slices.Contains from the standard library instead.
+// This function will be removed in v1.0.0.
+//
+// Migration:
+//
+//	import "slices"
+//	slices.Contains(mySlice, value)
 func Contains[S ~[]E, E comparable](s S, v E) bool {
-	return Index(s, v) >= 0
+	return slices.Contains(s, v)
 }

--- a/contains_test.go
+++ b/contains_test.go
@@ -1,5 +1,8 @@
 package slices
 
+// NOTE: The Contains function is deprecated in favor of slices.Contains from the standard library.
+// Tests are maintained for backward compatibility until v1.0.0.
+
 import (
 	"context"
 	"errors"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spandigital/slices
 
-go 1.24.0
+go 1.25
 
 require (
 	github.com/cucumber/godog v0.15.1

--- a/groupbylen.go
+++ b/groupbylen.go
@@ -1,5 +1,19 @@
 package slices
 
+// GroupByLen splits input into chunks of the specified length.
+//
+// Deprecated: Use slices.Chunk from the standard library instead.
+// This function will be removed in v1.0.0.
+// Note that slices.Chunk returns an iterator, not a materialized slice.
+//
+// Migration:
+//
+//	import "slices"
+//	// To collect into a slice of slices:
+//	var result [][]V
+//	for chunk := range slices.Chunk(mySlice, length) {
+//	    result = append(result, chunk)
+//	}
 func GroupByLen[S ~[]V, V any](input S, length int) (output [][]V) {
 	if length < 1 {
 		panic("length must be greater than or equal to 1")

--- a/groupbylen_test.go
+++ b/groupbylen_test.go
@@ -1,5 +1,8 @@
 package slices
 
+// NOTE: The GroupByLen function is deprecated in favor of slices.Chunk from the standard library.
+// Tests are maintained for backward compatibility until v1.0.0.
+
 import (
 	"context"
 	"errors"

--- a/index.go
+++ b/index.go
@@ -1,12 +1,17 @@
 package slices
 
+import "slices"
+
 // Index returns the index of the first occurrence of v in s,
 // or -1 if not present.
+//
+// Deprecated: Use slices.Index from the standard library instead.
+// This function will be removed in v1.0.0.
+//
+// Migration:
+//
+//	import "slices"
+//	slices.Index(mySlice, value)
 func Index[S ~[]E, E comparable](s S, v E) int {
-	for i := range s {
-		if v == s[i] {
-			return i
-		}
-	}
-	return -1
+	return slices.Index(s, v)
 }

--- a/index_test.go
+++ b/index_test.go
@@ -1,5 +1,8 @@
 package slices
 
+// NOTE: The Index function is deprecated in favor of slices.Index from the standard library.
+// Tests are maintained for backward compatibility until v1.0.0.
+
 import (
 	"context"
 	"errors"


### PR DESCRIPTION
## Summary

Deprecates three functions that are now available in the Go standard library `slices` package:
- `Contains` → `slices.Contains` (Go 1.21+)
- `Index` → `slices.Index` (Go 1.21+)
- `GroupByLen` → `slices.Chunk` (Go 1.23+)

## Changes

- Added deprecation comments with migration examples
- Updated Contains and Index to call stdlib implementations
- Upgraded Go version requirement from 1.24 to 1.25
- Updated README.md with deprecation notice and migration guide
- Updated CLAUDE.md with deprecation policy
- All functions remain functional for backward compatibility

## Breaking Changes

This is a **non-breaking deprecation**. Functions will be removed in v1.0.0.

Users should migrate to stdlib equivalents:
- Direct replacements for Contains and Index
- Iterator-based approach for GroupByLen using slices.Chunk

## Version Impact

- Target: v0.11.0 (minor version bump for deprecation)
- Functions will be removed in: v1.0.0

## Testing

✅ All tests pass
✅ Deprecated functions still work correctly
✅ Builds successfully with Go 1.25

## References

- [Go slices package documentation](https://pkg.go.dev/slices)
- [Go 1.25 Release Notes](https://go.dev/doc/go1.25)